### PR TITLE
Add dplyr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports: 
     DBI,
+    dplyr,
     glue,
     odbc

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,8 @@
 export(connect_to_etn)
 export(get_acoustic_detections)
 export(list_animal_ids)
+importFrom(dplyr,"%>%")
+importFrom(dplyr,.data)
+importFrom(dplyr,distinct)
+importFrom(dplyr,filter)
+importFrom(dplyr,pull)

--- a/R/etnservice-package.R
+++ b/R/etnservice-package.R
@@ -1,0 +1,11 @@
+#' @keywords internal
+"_PACKAGE"
+
+## usethis namespace: start
+#' @importFrom dplyr %>%
+#' @importFrom dplyr .data
+#' @importFrom dplyr distinct
+#' @importFrom dplyr filter
+#' @importFrom dplyr pull
+## usethis namespace: end
+NULL


### PR DESCRIPTION
Resolves #6 

ETN is currently dependent on `dplyr`, but this was not declared for this fork causing issues on the hosted instance. A number of functions are loaded into the namespace. I didn't check manually if they are all in use, but I'm pretty sure they will be in the future. 

- .data
- pull
- %>%
- filter
- distinct

Changes made to NAMESPACE and DESCRIPTION. Also created package level documentation, as required by `usethis::use_import_from()`