### PR TITLE
HTTP 403 on `write_dwc()` API call

### DIFF
--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -88,9 +88,10 @@ write_dwc <- function(credentials = list(
   # message("Reading data and transforming to Darwin Core.")
 
   dwc_occurrence_sql <- glue::glue_sql(
-    .con = connection
     readr::read_file(system.file("sql/dwc_occurrence.sql",
                                  package = "etnservice")),
+    .con = connection,
+    .null = "NULL"
   )
   dwc_occurrence <- DBI::dbGetQuery(connection, dwc_occurrence_sql)
 

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -57,6 +57,8 @@ write_dwc <- function(credentials = list(
     length(animal_project_code) == 1,
     msg = "`animal_project_code` must be a single value."
   )
+  ## Set animal project code to lowercase for sql
+  animal_project_code <- stringr::str_to_lower(animal_project_code)
 
   # Check license
   licenses <- c("CC-BY", "CC0")

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -2,7 +2,7 @@
 #'
 #' Transforms and downloads data from a European Tracking Network
 #' **animal project** to [Darwin Core](https://dwc.tdwg.org/).
-#' The resulting CSV file(s) can be uploaded to an [IPT](
+#' The resulting tibble can be saved as a CSV and be uploaded to an [IPT](
 #' https://www.gbif.org/ipt) for publication to OBIS and/or GBIF.
 #' A `meta.xml` or `eml.xml` file are not created.
 #'

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -88,8 +88,9 @@ write_dwc <- function(credentials = list(
   # message("Reading data and transforming to Darwin Core.")
 
   dwc_occurrence_sql <- glue::glue_sql(
-    readr::read_file(system.file("sql/dwc_occurrence.sql", package = "etn")),
     .con = connection
+    readr::read_file(system.file("sql/dwc_occurrence.sql",
+                                 package = "etnservice")),
   )
   dwc_occurrence <- DBI::dbGetQuery(connection, dwc_occurrence_sql)
 

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -2,7 +2,7 @@
 #'
 #' Transforms and downloads data from a European Tracking Network
 #' **animal project** to [Darwin Core](https://dwc.tdwg.org/).
-#' The resulting tibble can be saved as a CSV and be uploaded to an [IPT](
+#' The resulting dataframe can be saved as a CSV and be uploaded to an [IPT](
 #' https://www.gbif.org/ipt) for publication to OBIS and/or GBIF.
 #' A `meta.xml` or `eml.xml` file are not created.
 #'
@@ -14,7 +14,7 @@
 #'   published.
 #'   - [`CC-BY`](https://creativecommons.org/licenses/by/4.0/legalcode) (default).
 #'   - [`CC0`](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
-#' @return list of data frames
+#' @return list of dataframes
 #' @export
 #' @section Transformation details:
 #' Data are transformed into an


### PR DESCRIPTION
This PR assumes the error is caused by referring to a SQL file that might not be present on the OpenCPU server, because ETN might not be installed on the instance. 

I've always meant to use the SQL file provided in etn service, and this dependency on etn was a leftover from the fork and not intended. 

Some other functionality from `etn`, including a change to NULL behaviour in `glue_sql()` that resulted in `write_dwc()` not working in `etn v2.1.0` are implemented here. 

## Testing option 1

I could test the assumption around using a non existing sql file if I had a test server somewhere that did have the database, but not `etn` installed....

Sanne didn't have ´etn´ installed on a fresh account on the VLIZ RStudio server. But I'm unwilling to uninstall on my account. I could request a new account? 

## Testing option 2

Or have this merge in live-test and see if it works that way

## Todo

Setup postman test for `write_dwc()`