### PR TITLE
Update README examples

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -58,27 +58,28 @@ devtools::install_github("inbo/etnservice")
 This is a basic example which shows you how adress the API directly:
 
 ```{r example, eval = FALSE}
-library(httr) # to talk to the internet
+library(httr2) # to talk to the internet
 library(magrittr) # to use pipes
-library(jsonlite) # to work with JSON files
 library(askpass) # to safly enter a password in R
 
 # To access the ETN database, we need a login (username + password). We'll ask
 # for the password dynamically because that's safer than storing it as an object
-username <- "<your username here!>"
+username <- "<your-username-here>"
 # All functions can be adressed directly in the URL
-endpoint <- "https://opencpu.lifewatch.be/library/etn/R/list_animal_ids"
+endpoint <- "https://opencpu.lifewatch.be/library/etnservice/R/list_scientific_names"
 # Request the result of the function to be a json, and put in a request
 response <-
-    httr::POST(paste(endpoint, "json", sep = "/"),
-      body = list(
-        credentials = glue::glue('list(username = "{username}", password = "{askpass::askpass()}")')
-      )
-    )
+    httr2::request(endpoint) %>% 
+    ## In this case we'll request the data in JSON format and parse it
+    httr2::req_url_path_append("json") %>%
+    httr2::req_body_json(
+      list(credentials = list(username = username,
+                              password = askpass::askpass()))
+    ) %>% 
+    httr2::req_perform()
 # Take the response of the server, and convert it into an R object we can use
 response %>%
-    httr::content(as = "text", encoding = "UTF-8") %>%
-    jsonlite::fromJSON(simplifyVector = TRUE)
+    httr2::resp_body_json(simplifyVector = TRUE)
 
 ```
 
@@ -87,13 +88,12 @@ However, a fork of the [etn package](https://github.com/inbo/etn) is currently i
 Another example of the same request as above, but now using [curl](https://curl.se/):
 ```{bash,eval = FALSE}
 #! /bin/bash
-curl --location --request POST 'https://opencpu.lifewatch.be/library/etnservice/R/list_animal_ids/json' \
+curl --location 'https://opencpu.lifewatch.be/library/etnservice/R/list_scientific_names/json' \
 --header 'Content-Type: application/json' \
---header 'Cookie: vliz_webc=vliz_webc2' \
 --data-raw '{
     "credentials": {
-        "username": "<your username>",
-        "password": "<your password>"
+        "username": "<your-username-here>",
+        "password": "<your-password-here>"
     }
 }'
 ```


### PR DESCRIPTION
- I rewrote the R example to use `httr2`, and switched over to a quicker function call. 

- I removed a cookie line from the curl example

- The credentials syntax is slightly different, I believe, anyway, this is how it should be. 



## AI Summary

This pull request includes updates to the `README.md` and `README.Rmd` files to reflect changes in the API usage and improve code examples. The most important changes include switching from `httr` to `httr2`, updating the endpoint URLs, and modifying the example credentials format.

Updates to API usage:

* [`README.Rmd`](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL61-R82): Changed the library from `httr` to `httr2` and updated the endpoint URL in the R example code.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R78): Changed the library from `httr` to `httr2` and updated the endpoint URL in the R example code.

Improvements to code examples:

* [`README.Rmd`](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL90-R96): Updated the example credentials format and modified the endpoint URL in the bash example code.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R95): Updated the example credentials format and modified the endpoint URL in the bash example code.