### PR TITLE
Increment version number to 0.1.2 for release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # etnservice 0.1.2
+- Updated integration tests (javascript) -> for postman monitor
+- Updated broken readme example to work and use `httr2`
 
 # etnservice 0.1.1
 - Added badges to the readme

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # etnservice 0.1.2
-- Updated integration tests (javascript) -> for postman monitor
+- Updated integration tests (JavaScript) for postman monitor
 - Updated broken readme example to work and use `httr2`
 
 # etnservice 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# etnservice 0.1.2
+
 # etnservice 0.1.1
 - Added badges to the readme
 - Improvements to CI, note that tests and examples are not checked on github. These still need to be checked on a machine that has access to the ETN database.


### PR DESCRIPTION
I need a new release for the Zenodo integration to trigger, I'm testing zenodo coupling for ETN and using this repo as a stand-in. 


* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3): Updated the package version from 0.1.1 to 0.1.2.

* [`NEWS.md`](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR1-R4): Added a new section for version 0.1.2, including updates to integration tests and fixing a broken readme example to use `httr2`.