### PR TITLE
Allow `rights_holder = NULL` in `write_dwc()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.1.2
+Version: 0.1.2.9000
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.1.3
+Version: 0.1.2
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# etnservice 0.1.3
+# etnservice (development version)
 
 - Fixed bug in `write_dwc()` where providing no value for `rights_holder` would result in the function failing to output a data.frame (#69).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# etnservice 0.1.3
+
+- Fixed bug in `write_dwc()` where providing no value for `rights_holder` would result in the function failing to output a data.frame (#69).
+
 # etnservice 0.1.2
 
 - Updated integration tests (JavaScript) for postman monitor (#62).

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -60,6 +60,12 @@ write_dwc <- function(credentials = list(
   ## Set animal project code to lowercase for sql
   animal_project_code <- stringr::str_to_lower(animal_project_code)
 
+  # Check rightsholder
+
+  if (is.null(rights_holder)) {
+    rights_holder <- NA_character_
+  }
+
   # Check license
   licenses <- c("CC-BY", "CC0")
   assertthat::assert_that(

--- a/tests/testthat/test-write_dwc.R
+++ b/tests/testthat/test-write_dwc.R
@@ -52,3 +52,28 @@ test_that("write_dwc() returns the expected Darwin Core terms as columns", {
     )
   )
 })
+
+test_that("write_dwc() allows setting of rights_holder", {
+  result <- suppressMessages(
+    write_dwc(credentials,
+              animal_project_code = "2014_demer",
+              rights_holder = "< my rightholder value>")
+  )
+
+  expect_identical(
+    unique(result$dwc_occurrence$rightsHolder),
+    "< my rightholder value>"
+  )
+})
+
+test_that("write_dwc() returns an empty column for rights holder by default", {
+  result <- suppressMessages(
+    write_dwc(credentials,
+              animal_project_code = "2014_demer")
+  )
+
+  expect_identical(
+    unique(result$dwc_occurrence$rightsHolder),
+    NA_character_
+  )
+})

--- a/tests/testthat/test-write_dwc.R
+++ b/tests/testthat/test-write_dwc.R
@@ -57,12 +57,12 @@ test_that("write_dwc() allows setting of rights_holder", {
   result <- suppressMessages(
     write_dwc(credentials,
               animal_project_code = "2014_demer",
-              rights_holder = "< my rightholder value>")
+              rights_holder = "my_rightholder")
   )
 
   expect_identical(
     unique(result$dwc_occurrence$rightsHolder),
-    "< my rightholder value>"
+    "my_rightholder"
   )
 })
 


### PR DESCRIPTION
Fixes #68

Similar solution to movepub by casting `NULL` to `NA_character`. Prepearing for a 0.2.0 release I set the version here to a dev version. 

This work will need to be repeated for etn