### PR TITLE
Add `depth_in_meters` field to `get_acoustic_detections()`

### DIFF
--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -236,6 +236,7 @@ get_acoustic_detections <- function(credentials = list(
       deployment_station_name AS station_name, -- exclusive to detections_limited
       deployment_latitude AS deploy_latitude, -- exclusive to detections_limited
       deployment_longitude AS deploy_longitude, -- exclusive to detections_limited
+      det.depth_in_meters AS depth_in_meters,
       det.sensor_value AS sensor_value,
       det.sensor_unit AS sensor_unit,
       det.sensor2_value AS sensor2_value,

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -52,6 +52,7 @@ test_that("get_acoustic_detections() returns the expected columns", {
     "station_name",
     "deploy_latitude",
     "deploy_longitude",
+    "depth_in_meters",
     "sensor_value",
     "sensor_unit",
     "sensor2_value",


### PR DESCRIPTION
This pull request updates the `get_acoustic_detections` function to include the `depth_in_meters` field, equivalent to inbo/etn#274. This PR is necessary because this feature was only added to etn after etnservice was forked. Because etn becomes fully dependent on etnservice in inbo/etn#317, the missing field here would cause a regression in functionality for the etn package.

## Changes made
### Functionality enhancement:
* [`R/get_acoustic_detections.R`](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8R239): Added a new column, `depth_in_meters`, to the query in the `get_acoustic_detections` function. This provides additional information about the depth of detections.

### Test coverage update:
* [`tests/testthat/test-get_acoustic_detections.R`](diffhunk://#diff-a3c21c8af370ba054f6659a23eaf2ed0e35fb9c3c5d3c376725524e6b2ba69abR55): Updated the test for `get_acoustic_detections()` to include `depth_in_meters` in the list of expected columns, ensuring the new functionality is properly validated.