### PR TITLE
Development release v0.3.0.9005

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.3.0.9004
+Version: 0.3.0.9005
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/R/get_version.R
+++ b/R/get_version.R
@@ -29,6 +29,6 @@ get_version <- function() {
   # etnservice
   list(
     fn_checksums = purrr::map(fn_code, rlang::hash),
-    version = utils::packageVersion("etnservice")
+    version = as.character(utils::packageVersion("etnservice"))
   )
 }

--- a/tests/testthat/test-get_version.R
+++ b/tests/testthat/test-get_version.R
@@ -1,0 +1,21 @@
+test_that("get_version() returns a version object as character", {
+  expect_type(get_version()$version,
+                  "character")
+})
+
+test_that("get_version() returns installed etnservice version", {
+  expect_identical(
+    get_version()$version,
+    installed.packages(noCache = TRUE) %>%
+      dplyr::as_tibble() %>%
+      dplyr::filter(Package == "etnservice") %>%
+      dplyr::pull("Version")
+  )
+})
+
+test_that("get_version() returns both the version number and hashes of function code", {
+  expect_named(
+    get_version(),
+    c("fn_checksums", "version")
+  )
+})


### PR DESCRIPTION
Small patch to stop `get_version()` form returning an `package_version` S3 object.