### PR TITLE
`get_acoustic_detections_page()` should support `deployment_id` argument instead of `detection_id`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.3.0.9005
+Version: 0.3.0.9006
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -22,6 +22,7 @@
 #' @param scientific_name Character (vector). One or more scientific names.
 #' @param acoustic_project_code Character (vector). One or more acoustic project
 #'   codes. Case-insensitive.
+#' @param deployment_id
 #' @param receiver_id Character (vector). One or more receiver identifiers.
 #' @param station_name Character (vector). One or more deployment station names.
 #' @param count Logical. If set to `TRUE` a data.frame is returned with a single
@@ -45,6 +46,7 @@ get_acoustic_detections_page <- function(credentials = list(
                                          animal_project_code = NULL,
                                          scientific_name = NULL,
                                          acoustic_project_code = NULL,
+                                         deployment_id = NULL,
                                          receiver_id = NULL,
                                          station_name = NULL,
                                          count = FALSE) {
@@ -138,6 +140,9 @@ get_acoustic_detections_page <- function(credentials = list(
     )
   }
 
+  # Check deployment id
+
+
   # Check receiver_id
   if (is.null(receiver_id)) {
     receiver_id_query <- "True"
@@ -208,6 +213,7 @@ get_acoustic_detections_page <- function(credentials = list(
       AND {animal_project_code_query}
       AND {scientific_name_query}
       AND {acoustic_project_code_query}
+      AND {deployment_id_query}
       AND {receiver_id_query}
       AND {station_name_query}
       AND det.detection_id_pk > {next_id_pk}

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -16,7 +16,6 @@
 #'   `yyyy-mm-dd`, `yyyy-mm` or `yyyy`).
 #' @param end_date Character. End date (exclusive) in ISO 8601 format (
 #'   `yyyy-mm-dd`, `yyyy-mm` or `yyyy`).
-#' @param detection_id Integer (vector). One or more detection ids.
 #' @param acoustic_tag_id Character (vector). One or more acoustic tag ids.
 #' @param animal_project_code Character (vector). One or more animal project
 #'   codes. Case-insensitive.
@@ -75,18 +74,6 @@ get_acoustic_detections_page <- function(credentials = list(
     end_date <- check_date_time(end_date, "end_date")
     end_date_query <- glue::glue_sql("det.datetime < {end_date}",
                                      .con = connection)
-  }
-
-  # Check detection_id
-  if (is.null(detection_id)) {
-    detection_id_query <- "True"
-  } else {
-    assertthat::assert_that(is.integer(detection_id))
-
-    detection_id_query <- glue::glue_sql(
-      "detection_id_pk IN ({detection_id*})",
-      .con = connection
-    )
   }
 
   # Check acoustic_tag_id
@@ -217,7 +204,6 @@ get_acoustic_detections_page <- function(credentials = list(
     WHERE
       {start_date_query}
       AND {end_date_query}
-      AND {detection_id_query}
       AND {acoustic_tag_id_query}
       AND {animal_project_code_query}
       AND {scientific_name_query}

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -141,7 +141,19 @@ get_acoustic_detections_page <- function(credentials = list(
   }
 
   # Check deployment id
-
+  if (is.null(deployment_id)) {
+    deployment_id_query <- "True"
+  } else {
+    deployment_id <- check_value(
+      deployment_id,
+      list_deployment_ids(credentials),
+      "deployment_id"
+    )
+    deployment_id_query <- glue::glue_sql(
+      "det.deployment_fk IN ({deployment_id*})",
+      .con = connection
+    )
+  }
 
   # Check receiver_id
   if (is.null(receiver_id)) {

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -22,7 +22,7 @@
 #' @param scientific_name Character (vector). One or more scientific names.
 #' @param acoustic_project_code Character (vector). One or more acoustic project
 #'   codes. Case-insensitive.
-#' @param deployment_id
+#' @param deployment_id Character (vector). One or more deployment ids.
 #' @param receiver_id Character (vector). One or more receiver identifiers.
 #' @param station_name Character (vector). One or more deployment station names.
 #' @param count Logical. If set to `TRUE` a data.frame is returned with a single

--- a/man/get_acoustic_detections_page.Rd
+++ b/man/get_acoustic_detections_page.Rd
@@ -15,6 +15,7 @@ get_acoustic_detections_page(
   animal_project_code = NULL,
   scientific_name = NULL,
   acoustic_project_code = NULL,
+  deployment_id = NULL,
   receiver_id = NULL,
   station_name = NULL,
   count = FALSE
@@ -47,6 +48,8 @@ codes. Case-insensitive.}
 
 \item{acoustic_project_code}{Character (vector). One or more acoustic project
 codes. Case-insensitive.}
+
+\item{deployment_id}{Character (vector). One or more deployment ids.}
 
 \item{receiver_id}{Character (vector). One or more receiver identifiers.}
 

--- a/man/get_acoustic_detections_page.Rd
+++ b/man/get_acoustic_detections_page.Rd
@@ -38,8 +38,6 @@ have a detection_id higher than next_id_pk.}
 \item{end_date}{Character. End date (exclusive) in ISO 8601 format (
 \code{yyyy-mm-dd}, \code{yyyy-mm} or \code{yyyy}).}
 
-\item{detection_id}{Integer (vector). One or more detection ids.}
-
 \item{acoustic_tag_id}{Character (vector). One or more acoustic tag ids.}
 
 \item{animal_project_code}{Character (vector). One or more animal project


### PR DESCRIPTION
## AI Summary

This pull request updates the `get_acoustic_detections_page` function to remove filtering by `detection_id` and adds support for filtering by `deployment_id`. Documentation has been updated to reflect these changes.

**API changes:**

* Removed the `detection_id` parameter from the `get_acoustic_detections_page` function and its documentation, including its usage in the SQL query. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84L19-R25) [[2]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84L80-L91) [[3]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84L220-R228) [[4]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eL41-L42)
* Added a new `deployment_id` parameter to the function, implemented its validation, and incorporated it into the SQL query for filtering results. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84L19-R25) [[2]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R49) [[3]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R143-R157) [[4]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84L220-R228) [[5]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR18) [[6]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR52-R53)

**Documentation updates:**

* Updated the function documentation in both the Roxygen comments and the `.Rd` manual file to reflect the removal of `detection_id` and the addition of `deployment_id`. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84L19-R25) [[2]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eL41-L42) [[3]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR52-R53)

**Version bump:**

* Incremented the package version in `DESCRIPTION` to `0.3.0.9006` to reflect these changes.