### PR TITLE
104 client package etn needs arrow codec lz4 installed via arrow : not presently installed via opencpu suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,10 @@ Authors@R: c(
 Description: Provides API endpoints to the European Tracking Network.
     Designed to be used with OpenCPU and the 'etn' package.
 License: MIT + file LICENSE
+URL: https://github.com/inbo/etnservice
+BugReports: https://github.com/inbo/etnservice/issues
 Imports: 
+    arrow,
     assertthat,
     DBI,
     dplyr,
@@ -27,8 +30,7 @@ Imports:
     readr,
     rlang,
     stringr,
-    utils,
-    arrow
+    utils
 Suggests: 
     purrr,
     testthat (>= 3.0.0)
@@ -36,5 +38,3 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-URL: https://github.com/inbo/etnservice
-BugReports: https://github.com/inbo/etnservice/issues


### PR DESCRIPTION
I'm trying to force OpenCPU to install Arrow so I have access to the lz4 codec, if this works I need to get to VLIZ so they can change this in the container directly rather than as a etnservice dependency. 

--- 


## AI Summary

This pull request updates the `DESCRIPTION` file to improve package metadata and dependencies. The main changes are the addition of new fields for repository information and the inclusion of the `arrow` package in the list of imports.

Metadata improvements:

* Added `URL` and `BugReports` fields to provide links to the GitHub repository and issue tracker.
* Removed duplicate `URL` and `BugReports` fields from the bottom of the file to avoid redundancy.

Dependency updates:

* Added the `arrow` package to the `Imports` section, indicating it is now required by the package.