### PR TITLE
Return `package_version`, `numeric_version` objects as part of output for `get_version()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.4.2
+Version: 0.4.2.9000
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # etnservice (development version)
+- `get_version()` now returns the package version as a `package_version`, `numeric_version` object instead of as a character string. This allows for easy comparison by the `etn` package. (#109)
 
 # etnservice 0.4.2
 - Minor change to `get_acoustic_detections_page()` to now support ellipsis `...` to be passed (unused). This is useful when the function is being called via `do.call()` and extra arguments are passed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# etnservice (development version)
+
 # etnservice 0.4.2
 - Minor change to `get_acoustic_detections_page()` to now support ellipsis `...` to be passed (unused). This is useful when the function is being called via `do.call()` and extra arguments are passed.
 

--- a/R/get_version.R
+++ b/R/get_version.R
@@ -29,6 +29,6 @@ get_version <- function() {
   # etnservice
   list(
     fn_checksums = purrr::map(fn_code, rlang::hash),
-    version = as.character(utils::packageVersion("etnservice"))
+    version = utils::packageVersion("etnservice")
   )
 }

--- a/tests/testthat/test-get_version.R
+++ b/tests/testthat/test-get_version.R
@@ -1,11 +1,10 @@
-test_that("get_version() returns a version object as character", {
-  expect_type(get_version()$version,
-                  "character")
+test_that("get_version() returns a version object as `package_version`", {
+  expect_s3_class(get_version()$version, "package_version")
 })
 
 test_that("get_version() returns installed etnservice version", {
   expect_identical(
-    get_version()$version,
+    as.character(get_version()$version),
     installed.packages(noCache = TRUE) %>%
       dplyr::as_tibble() %>%
       dplyr::filter(Package == "etnservice") %>%


### PR DESCRIPTION
> It would be handy if the client could compare package versions, as to not prompt for an update if the client has a more recent version installed than available on the OpenCPU deployment.

> Currently the package version is cast into character, I think I should only do this on the client side, not on the service side.

Since this function is not user facing to `etn`, this change mostly has impact on the development workflow. It is a requirement for inbo/etn#385

## AI Summary

This pull request introduces a development version for the `etnservice` package and updates version reporting. The changes are primarily related to versioning and documentation.

Versioning and documentation updates:

* Updated the package version in `DESCRIPTION` to `0.4.2.9000` to indicate a development version.
* Added a new section for the development version in `NEWS.md` to track changes.
* Modified `get_version()` in `R/get_version.R` to return the `version` as a `package_version` object instead of a character string.