### PR TITLE
prepare v0.4.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.4.2
+Version: 0.4.2.9000
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# etnservice (development version)
+- `get_version()` now returns the package version as a `package_version`, `numeric_version` object instead of as a character string. This allows for easy comparison by the `etn` package. (#109)
+
 # etnservice 0.4.2
 - Minor change to `get_acoustic_detections_page()` to now support ellipsis `...` to be passed (unused). This is useful when the function is being called via `do.call()` and extra arguments are passed.
 

--- a/R/get_version.R
+++ b/R/get_version.R
@@ -29,6 +29,6 @@ get_version <- function() {
   # etnservice
   list(
     fn_checksums = purrr::map(fn_code, rlang::hash),
-    version = as.character(utils::packageVersion("etnservice"))
+    version = utils::packageVersion("etnservice")
   )
 }

--- a/tests/testthat/test-get_version.R
+++ b/tests/testthat/test-get_version.R
@@ -1,11 +1,10 @@
-test_that("get_version() returns a version object as character", {
-  expect_type(get_version()$version,
-                  "character")
+test_that("get_version() returns a version object as `package_version`", {
+  expect_s3_class(get_version()$version, "package_version")
 })
 
 test_that("get_version() returns installed etnservice version", {
   expect_identical(
-    get_version()$version,
+    as.character(get_version()$version),
     installed.packages(noCache = TRUE) %>%
       dplyr::as_tibble() %>%
       dplyr::filter(Package == "etnservice") %>%


### PR DESCRIPTION
This pull request updates the way the package version is handled and returned by the `get_version()` function, improving compatibility with version comparisons in other packages. It also updates related documentation and tests to reflect this change.

Version handling improvements:

* [`R/get_version.R`](diffhunk://#diff-5889b45b6b41d7ae50f09beb05314dc57e6171112ad40be257fbd7684fa9b715L32-R32): The `get_version()` function now returns the package version as a `package_version` (or `numeric_version`) object instead of a character string, making it easier to compare versions programmatically.
* [`NEWS.md`](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR1-R3): Added a note describing the change in how `get_version()` returns the version object for easier comparison by the `etn` package.

Documentation and testing updates:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3): Updated the package version to `0.4.2.9000` to indicate a development version.
* [`tests/testthat/test-get_version.R`](diffhunk://#diff-3dd133d3c9c152d516bcf012875094359cbd0eec7f422bbfee7bb8210aef2ad1L1-R7): Updated tests to check that `get_version()$version` is a `package_version` object and adjusted version comparison logic accordingly.