### PR TITLE
Implement `tag_serial_number` in `get_acoustic_detections_page()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # etnservice (development version)
+- Added `tag_serial_number` to `get_acoustic_detections_page()`. This argument is a better option as `tag_serial_number`. Thank you @lottepohl for the suggestion. (#112, inbo/etn#386, #102)
 
 # etnservice 0.4.3
 - `get_version()` now returns the package version as a `package_version`, `numeric_version` object instead of as a character string. This allows for easy comparison by the `etn` package. (#109)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # etnservice (development version)
-- Added `tag_serial_number` to `get_acoustic_detections_page()`. This argument is a better option as `tag_serial_number`. Thank you @lottepohl for the suggestion. (#112, inbo/etn#386, #102)
+- Added `tag_serial_number` to `get_acoustic_detections_page()`. This argument is a better option as `acoustic_tag_id`. Thank you @lottepohl for the suggestion. (#112, inbo/etn#386, #102)
 
 # etnservice 0.4.3
 - `get_version()` now returns the package version as a `package_version`, `numeric_version` object instead of as a character string. This allows for easy comparison by the `etn` package. (#109)

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -16,6 +16,7 @@
 #'   `yyyy-mm-dd`, `yyyy-mm` or `yyyy`).
 #' @param end_date Character. End date (exclusive) in ISO 8601 format (
 #'   `yyyy-mm-dd`, `yyyy-mm` or `yyyy`).
+#' @param tag_serial_number Character (vector). One or more tag serial numbers.
 #' @param acoustic_tag_id Character (vector). One or more acoustic tag ids.
 #' @param animal_project_code Character (vector). One or more animal project
 #'   codes. Case-insensitive.
@@ -269,7 +270,6 @@ get_acoustic_detections_page <- function(credentials = list(
         date_time = .data$datetime,
         .data$tag_serial_number,
         acoustic_tag_id = .data$transmitter,
-        .data$tag_serial_number,
         .data$animal_project_code,
         animal_id = .data$animal_id_pk,
         scientific_name = .data$animal_scientific_name,

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -43,6 +43,7 @@ get_acoustic_detections_page <- function(credentials = list(
                                          page_size = 100000,
                                          start_date = NULL,
                                          end_date = NULL,
+                                         tag_serial_number = NULL,
                                          acoustic_tag_id = NULL,
                                          animal_project_code = NULL,
                                          scientific_name = NULL,
@@ -78,6 +79,21 @@ get_acoustic_detections_page <- function(credentials = list(
     end_date <- check_date_time(end_date, "end_date")
     end_date_query <- glue::glue_sql("det.datetime < {end_date}",
                                      .con = connection)
+  }
+
+  # Check tag_serial_number
+  if (is.null(tag_serial_number)) {
+    tag_serial_number_query <- "True"
+  } else {
+    tag_serial_number <- check_value(
+      tag_serial_number,
+      list_tag_serial_numbers(credentials),
+      "tag_serial_number"
+    )
+    tag_serial_number_query <- glue::glue_sql(
+      "det.tag_serial_number IN ({tag_serial_number*})",
+      .con = connection
+    )
   }
 
   # Check acoustic_tag_id
@@ -223,6 +239,7 @@ get_acoustic_detections_page <- function(credentials = list(
     WHERE
       {start_date_query}
       AND {end_date_query}
+      AND {tag_serial_number_query}
       AND {acoustic_tag_id_query}
       AND {animal_project_code_query}
       AND {scientific_name_query}
@@ -252,6 +269,7 @@ get_acoustic_detections_page <- function(credentials = list(
         date_time = .data$datetime,
         .data$tag_serial_number,
         acoustic_tag_id = .data$transmitter,
+        .data$tag_serial_number,
         .data$animal_project_code,
         animal_id = .data$animal_id_pk,
         scientific_name = .data$animal_scientific_name,

--- a/man/get_acoustic_detections_page.Rd
+++ b/man/get_acoustic_detections_page.Rd
@@ -10,6 +10,7 @@ get_acoustic_detections_page(
   page_size = 1e+05,
   start_date = NULL,
   end_date = NULL,
+  tag_serial_number = NULL,
   acoustic_tag_id = NULL,
   animal_project_code = NULL,
   scientific_name = NULL,
@@ -38,6 +39,8 @@ have a detection_id higher than next_id_pk.}
 
 \item{end_date}{Character. End date (exclusive) in ISO 8601 format (
 \code{yyyy-mm-dd}, \code{yyyy-mm} or \code{yyyy}).}
+
+\item{tag_serial_number}{Character (vector). One or more tag serial numbers.}
 
 \item{acoustic_tag_id}{Character (vector). One or more acoustic tag ids.}
 

--- a/tests/testthat/test-get_acoustic_detections_page.R
+++ b/tests/testthat/test-get_acoustic_detections_page.R
@@ -109,6 +109,10 @@ test_that("get_acoustic_detections_page() returns the expected columns", {
     "deployment_id"
   )
   expect_equal(names(df), expected_col_names)
+  expect_named(df, expected_col_names)
+})
+
+test_that("get_acoustic_detections_page() returns only count column on count", {
   expect_named(
     get_acoustic_detections_page(acoustic_project_code = "2024_bovenschelde",
                                  count = TRUE),

--- a/tests/testthat/test-get_acoustic_detections_page.R
+++ b/tests/testthat/test-get_acoustic_detections_page.R
@@ -119,3 +119,17 @@ test_that("get_acoustic_detections_page() returns only count column on count", {
                                  count = TRUE),
     "count")
 })
+
+test_that("pagination via next_id_pk returns non-overlapping pages", {
+  first_page <- get_acoustic_detections_page(page_size = 300)
+  expect_true(nrow(first_page) > 0)
+  max_id_first_page <- max(first_page$detection_id)
+
+  second_page <- get_acoustic_detections_page(
+    page_size = 300,
+    next_id_pk = max_id_first_page
+  )
+
+  expect_true(all(second_page$detection_id > max_id_first_page))
+  expect_length(intersect(first_page$detection_id, second_page$detection_id), 0)
+})

--- a/tests/testthat/test-get_acoustic_detections_page.R
+++ b/tests/testthat/test-get_acoustic_detections_page.R
@@ -108,6 +108,7 @@ test_that("get_acoustic_detections_page() returns the expected columns", {
     "qc_flag",
     "deployment_id"
   )
+  expect_length(names(df), length(expected_col_names))
   expect_equal(names(df), expected_col_names)
   expect_named(df, expected_col_names)
 })


### PR DESCRIPTION
## AI Summary
This pull request adds support for filtering acoustic detections by tag serial number in the `get_acoustic_detections_page()` function. The changes update the function signature, documentation, SQL query logic, and tests to incorporate this new feature.

**Feature addition:**

* Added a new `tag_serial_number` argument to the `get_acoustic_detections_page()` function, allowing users to filter results by one or more tag serial numbers. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R19) [[2]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R47) [[3]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR13)
* Updated the SQL query logic in `get_acoustic_detections_page()` to include filtering by `tag_serial_number`, with input validation and query construction. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R85-R99) [[2]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R243)
* Updated the documentation in both `NEWS.md` and the Rd file to describe the new argument and its usage. [[1]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR2) [[2]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR43-R44)

**Testing:**

* Added and updated tests to ensure the new `tag_serial_number` argument works as expected and that output columns remain correct.

**Other:**

* Minor update to the selection of output columns to include `tag_serial_number`.