### PR TITLE
Prepare for v0.4.4 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.4.3.9000
+Version: 0.4.3.9002
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.4.3
+Version: 0.4.3.9000
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etnservice
 Title: Serve Data from the European Tracking Network
-Version: 0.4.3.9002
+Version: 0.4.3.9003
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # etnservice (development version)
+- Added `tag_serial_number` to `get_acoustic_detections_page()`. This argument is a better option as `acoustic_tag_id`. Thank you @lottepohl for the suggestion. (#112, inbo/etn#386, #102)
 
 # etnservice 0.4.3
 - `get_version()` now returns the package version as a `package_version`, `numeric_version` object instead of as a character string. This allows for easy comparison by the `etn` package. (#109)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# etnservice (development version)
+
 # etnservice 0.4.3
 - `get_version()` now returns the package version as a `package_version`, `numeric_version` object instead of as a character string. This allows for easy comparison by the `etn` package. (#109)
 

--- a/man/get_acoustic_detections_page.Rd
+++ b/man/get_acoustic_detections_page.Rd
@@ -10,6 +10,7 @@ get_acoustic_detections_page(
   page_size = 1e+05,
   start_date = NULL,
   end_date = NULL,
+  tag_serial_number = NULL,
   acoustic_tag_id = NULL,
   animal_project_code = NULL,
   scientific_name = NULL,
@@ -38,6 +39,8 @@ have a detection_id higher than next_id_pk.}
 
 \item{end_date}{Character. End date (exclusive) in ISO 8601 format (
 \code{yyyy-mm-dd}, \code{yyyy-mm} or \code{yyyy}).}
+
+\item{tag_serial_number}{Character (vector). One or more tag serial numbers.}
 
 \item{acoustic_tag_id}{Character (vector). One or more acoustic tag ids.}
 

--- a/tests/testthat/test-get_acoustic_detections_page.R
+++ b/tests/testthat/test-get_acoustic_detections_page.R
@@ -108,9 +108,28 @@ test_that("get_acoustic_detections_page() returns the expected columns", {
     "qc_flag",
     "deployment_id"
   )
+  expect_length(names(df), length(expected_col_names))
   expect_equal(names(df), expected_col_names)
+  expect_named(df, expected_col_names)
+})
+
+test_that("get_acoustic_detections_page() returns only count column on count", {
   expect_named(
     get_acoustic_detections_page(acoustic_project_code = "2024_bovenschelde",
                                  count = TRUE),
     "count")
+})
+
+test_that("pagination via next_id_pk returns non-overlapping pages", {
+  first_page <- get_acoustic_detections_page(page_size = 300)
+  expect_true(nrow(first_page) > 0)
+  max_id_first_page <- max(first_page$detection_id)
+
+  second_page <- get_acoustic_detections_page(
+    page_size = 300,
+    next_id_pk = max_id_first_page
+  )
+
+  expect_true(all(second_page$detection_id > max_id_first_page))
+  expect_length(intersect(first_page$detection_id, second_page$detection_id), 0)
 })


### PR DESCRIPTION
## AI Summary

This pull request adds a new `tag_serial_number` argument to the `get_acoustic_detections_page()` function, allowing users to filter detections by tag serial number in addition to the existing `acoustic_tag_id` filter. The documentation and tests have been updated to reflect this new feature.

**New feature: tag serial number filtering**
* Added a `tag_serial_number` argument to the `get_acoustic_detections_page()` function, enabling filtering by one or more tag serial numbers. This is an improved option over `acoustic_tag_id`. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R19) [[2]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R47) [[3]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R85-R99) [[4]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R243)
* Updated documentation in both the function's Roxygen comments and the `.Rd` file to describe the new `tag_serial_number` argument. [[1]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R19) [[2]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR13) [[3]](diffhunk://#diff-ef92791e3736857932f456d9d7a2e48cf911bc2e9908a1b1145932868529a41eR43-R44)
* Added a note in `NEWS.md` about the new argument and credited the contributor who suggested it.

**Testing improvements**
* Expanded tests for `get_acoustic_detections_page()` to check for correct column names, count-only queries, and non-overlapping pagination.

**Miscellaneous**
* Updated the package version to `0.4.3.9003` to mark the development version.