### PR TITLE
Use locale independent sorting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # etnservice (development version)
+- Made sure `list_acoustic_project_codes()`, `list_animal_project_codes()`, `list_cpod_project_codes()` and `list_scientific_names()` always return values in the same order, regardless of the locale of the computer R is running on. (#116)
 
 # etnservice 0.5.0
 - Added `tag_serial_number` to `get_acoustic_detections_page()`. This argument is a better option as `acoustic_tag_id`. Thank you @lottepohl for the suggestion. (#112, inbo/etn#386, #102)

--- a/R/list_acoustic_project_codes.R
+++ b/R/list_acoustic_project_codes.R
@@ -26,5 +26,5 @@ list_acoustic_project_codes <- function(credentials = list(
   DBI::dbDisconnect(connection)
 
   # Return acoustic_project_codes
-  sort(data$project_code)
+  stringr::str_sort(data$project_code)
 }

--- a/R/list_animal_project_codes.R
+++ b/R/list_animal_project_codes.R
@@ -25,5 +25,5 @@ list_animal_project_codes <- function(credentials = list(
   # Close connection
   DBI::dbDisconnect(connection)
 
-  sort(data$project_code)
+  stringr::str_sort(data$project_code)
 }

--- a/R/list_cpod_project_codes.R
+++ b/R/list_cpod_project_codes.R
@@ -33,5 +33,5 @@ list_cpod_project_codes <- function(credentials = list(
   # Close connection
   DBI::dbDisconnect(connection)
 
-  sort(data$project_code)
+  stringr::str_sort(data$project_code)
 }

--- a/R/list_scientific_names.R
+++ b/R/list_scientific_names.R
@@ -20,5 +20,5 @@ list_scientific_names <- function(credentials = list(
   # Close connection
   DBI::dbDisconnect(connection)
 
-  sort(data$scientific_name)
+  stringr::str_sort(data$scientific_name)
 }


### PR DESCRIPTION
Some functions already used ´stringr::str_sort()´ often with ´numeric = TRUE´. I've now switched the other listing functions over as well. Not setting ´numeric = TRUE´. I can still enable numeric sorting when I get feedback. Maybe I should by default? I have the tendency to stick to the stringr default values though...

Anyway, this should fix the bug where the order of the values returned by the listing functions can differ based on the computer locale, because stringr forced the locale to ´en´.