### PR TITLE
Remove missing acoustic project code from test.

### DIFF
--- a/tests/postman/test-list_acoustic_project_codes.js
+++ b/tests/postman/test-list_acoustic_project_codes.js
@@ -7,7 +7,7 @@ pm.test("returns the right acoustic project codes", () => {
       //array is not empty
       pm.expect(jsonData).to.not.be.empty;
       //ids include number of known values
-      pm.expect(jsonData).to.include.members(["Mobula_IMAR","Sudle_IMPULS","SVNL-FISH-WATCH","Inforbiomares","BOOGMR","ws2","zeeschelde","LESPUR","ws3","RESBIO","ST08SWE","PTN-Silver-eel-Mondego","Jersey_Coastal","Deveron","KBTN","FISHINTEL","Siganid_Gulf_Aqaba","Danube_Sturgeons","VVV","Walloneel","V2LCASP","BOOPIRATA","2015_PhD_Gutmann_Roberts","OTN_UPLOAD","NTNU-Gaulosen","BTN-IMEDEA","Reelease","AZO","PhD_Marrocco","2017_Fremur","paintedcomber","none","ARAISOLA03","PhysFish","life4fish","GIBRALTRACK_pilot","Artevigo","SEM","V2LGOL","SWIMWAY_2021","PhD_Jeremy_Pastor","PTN/PROTECT2012","MIGRATOEBRE","MOPP","V2LNR","eemskanaal_III"]);
+      pm.expect(jsonData).to.include.members(["Mobula_IMAR","Sudle_IMPULS","SVNL-FISH-WATCH","Inforbiomares","BOOGMR","ws2","zeeschelde","LESPUR","ws3","RESBIO","ST08SWE","PTN-Silver-eel-Mondego","Jersey_Coastal","Deveron","KBTN","FISHINTEL","Siganid_Gulf_Aqaba","Danube_Sturgeons","VVV","Walloneel","V2LCASP","BOOPIRATA","2015_PhD_Gutmann_Roberts","OTN_UPLOAD","NTNU-Gaulosen","BTN-IMEDEA","Reelease","AZO","PhD_Marrocco","2017_Fremur","paintedcomber","none","ARAISOLA03","PhysFish","life4fish","GIBRALTRACK_pilot","Artevigo","V2LGOL","SWIMWAY_2021","PhD_Jeremy_Pastor","PTN/PROTECT2012","MIGRATOEBRE","MOPP","V2LNR","eemskanaal_III"]);
   });
   
 pm.test("Response time is less than 3s", function () {


### PR DESCRIPTION
Remove `SEM` from postman test no longer returned by `list_acoustic_project_codes()`. This is probably due to a change in the database. 

The test was written to be sure that the output contains at least acoustic project codes, I'm not really too attached to which ones precisely. I think I selected the one's I test on at random anyway. 