### PR TITLE
Update postman test to expect integers.

### DIFF
--- a/tests/postman/test-list_deployment_ids.js
+++ b/tests/postman/test-list_deployment_ids.js
@@ -11,5 +11,5 @@ pm.test("returns the right deployment ids", () => {
       //array is not empty
       pm.expect(jsonData).to.not.be.empty;
       //ids include number of known values
-      pm.expect(jsonData).to.include.members(["54672", "28703", "26058", "10009", "8770", "27578", "4788", "6214", "56698", "1716", "65055", "55006", "3240", "1543", "12836"]);
+      pm.expect(jsonData).to.include.members([54672, 28703, 26058, 10009, 8770, 27578, 4788, 6214, 56698, 1716, 65055, 55006, 3240, 1543, 12836]);
   });


### PR DESCRIPTION
Test randomly started failing, I don't understand why. But I suppose it could have something to do with the recent postman update. 

https://www.postman.com/release-notes/postman-app/#12-0-1