### PR TITLE
Move `{jsonlite}` to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     dplyr,
     glue,
     httr,
-    jsonlite,
     lubridate,
     methods,
     odbc,
@@ -32,6 +31,7 @@ Imports:
     stringr,
     utils
 Suggests: 
+    jsonlite,
     purrr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # etnservice (development version)
-
+- The `jsonlite` package is no longer a direct dependency, it is only used by a maintenance script. (#144)
 # etnservice 0.6.0
 - Added `get_receiver_logs()` to fetch receiver logs from the database. The data is returned as a tibble with a column with logs in JSON format. (#117)
 


### PR DESCRIPTION
See #142

`jsonlite` is used by a dev script to process a postman collection export in easier to track test files in javascript. It is however not used by the package itself.


FYI: 

Arrow isn't used either, but the OpenCPU deployment needs it installed so it can export feather and parquet formats to the etn R package. By setting it as Imports here, I make sure it's always installed.