### PR TITLE
157 remove unused code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -251,8 +251,7 @@ get_acoustic_detections_page <- function(credentials = list(
       AND det.detection_id_pk > {next_id_pk}
     {limit_query}
     ",
-    .con = connection,
-    page_size_query = ifelse(count, "ALL", page_size)
+    .con = connection
   )
 
   # Execute query -----

--- a/man/etnservice-package.Rd
+++ b/man/etnservice-package.Rd
@@ -21,6 +21,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Pieter Huybrechts \email{pieter.huybrechts@inbo.be} (\href{https://orcid.org/0000-0002-6658-6062}{ORCID})
   \item Peter Desmet \email{peter.desmet@inbo.be} (\href{https://orcid.org/0000-0002-8442-8025}{ORCID})
 }
 


### PR DESCRIPTION
Housekeeping: Removed the unused `page_size_query` glue object from a `glue_sql` call in `R/get_acoustic_detections_page.