### PR TITLE
Adapt archival data tests to test on ids that are certainly present in the returned table

### DIFF
--- a/tests/testthat/test-get_archival_data_uuid.R
+++ b/tests/testthat/test-get_archival_data_uuid.R
@@ -38,34 +38,72 @@ test_that("get_archival_data_uuid() can query on animal_id", {
 })
 
 test_that("get_archival_data_uuid() can query on animal_project_code", {
-  selected_animal_project_code <- "2014_Frome"
-  project_uuid <-
-    get_archival_data_uuid(animal_project_code = selected_animal_project_code)
+  number_of_ids_to_test <- 3
+  get_archival_data_uuid()$animal_project_code |>
+    sample(size = number_of_ids_to_test) |>
+    purrr::walk(
+      \(selected_animal_project_code) {
+        project_uuid_df <-
+          get_archival_data_uuid(animal_project_code =
+                                   selected_animal_project_code)
+        expect_s3_class(
+          project_uuid_df,
+          "data.frame"
+        )
 
-  expect_s3_class(
-    project_uuid,
-    "data.frame"
-  )
-
-  expect_identical(
-    unique(project_uuid$animal_project_code),
-    selected_animal_project_code
-  )
+        expect_identical(
+          unique(project_uuid_df$animal_project_code),
+          selected_animal_project_code
+        )
+      }
+    )
 })
 
 test_that("get_archival_data_uuid() supports case insensitive animal_project_code", {
   selected_animal_project_code <- "2014_Frome"
 
-  expect_identical(
-    get_archival_data_uuid(
-      animal_project_code =
-        toupper(selected_animal_project_code)
-    ),
-    get_archival_data_uuid(
-      animal_project_code =
-        selected_animal_project_code
+  switch_case <- function(str) {
+    chartr(
+      old = paste(c(letters, LETTERS), collapse = ""),
+      new = paste(c(LETTERS, letters), collapse = ""),
+      x = str
     )
-  )
+  }
+
+  randomize_case <-
+    function(str) {
+      characters <- stringr::str_split(str, pattern = "")
+      # randomize some of the characters
+      purrr::map_chr(
+        characters,
+        \(chrs){
+          chrs_to_change <- sample(chrs, size = sample.int(length(chrs), size = 1L))
+          chartr(
+            old = paste(chrs_to_change, collapse = ""),
+            new = paste(switch_case(chrs_to_change), collapse = ""),
+            x = paste(chrs, collapse = "")
+          )
+        }
+      )
+    }
+  number_of_ids_to_test <- 5
+
+  # Test 5 random animal project codes
+  sample(unique(get_archival_data_uuid()$animal_project_code), size = number_of_ids_to_test) |>
+    purrr::walk(
+      \(selected_animal_project_code){
+        expect_identical(
+          get_archival_data_uuid(
+            animal_project_code =
+              randomize_case(selected_animal_project_code)
+          ),
+          get_archival_data_uuid(
+            animal_project_code =
+              selected_animal_project_code
+          )
+        )
+      }
+    )
 })
 
 test_that("get_archival_data_uuid() can query on tag_serial_number", {

--- a/tests/testthat/test-get_archival_data_uuid.R
+++ b/tests/testthat/test-get_archival_data_uuid.R
@@ -107,17 +107,20 @@ test_that("get_archival_data_uuid() supports case insensitive animal_project_cod
 })
 
 test_that("get_archival_data_uuid() can query on tag_serial_number", {
-  selected_tag_serial_number <- "1249189"
-  tag_uuid <-
-    get_archival_data_uuid(tag_serial_number = selected_tag_serial_number)
-  expect_s3_class(
-    tag_uuid,
-    "data.frame"
-  )
+  number_of_ids_to_test <- 3
+  sample(unique(get_archival_data_uuid()$tag_serial_number), size = number_of_ids_to_test) |>
+    purrr::walk(\(selected_tag_serial_number) {
+      tag_uuid <-
+        get_archival_data_uuid(tag_serial_number = selected_tag_serial_number)
+      expect_s3_class(
+        tag_uuid,
+        "data.frame"
+      )
 
-  expect_identical(
-    unique(tag_uuid$tag_serial_number),
-    selected_tag_serial_number
-  )
+      expect_identical(
+        unique(tag_uuid$tag_serial_number),
+        selected_tag_serial_number
+      )
+    })
 })
 

--- a/tests/testthat/test-get_archival_data_uuid.R
+++ b/tests/testthat/test-get_archival_data_uuid.R
@@ -18,8 +18,9 @@ test_that("get_archival_data_uuid() returns expected columns", {
 })
 
 test_that("get_archival_data_uuid() can query on animal_id", {
+  number_of_ids_to_test <- 3
   get_archival_data_uuid()$animal_id |>
-    sample(size = 3) |>
+    sample(size = number_of_ids_to_test) |>
     purrr::walk(
       \(selected_animal_id){
         animal_uuid_df <- get_archival_data_uuid(animal_id = selected_animal_id)

--- a/tests/testthat/test-get_archival_data_uuid.R
+++ b/tests/testthat/test-get_archival_data_uuid.R
@@ -18,19 +18,22 @@ test_that("get_archival_data_uuid() returns expected columns", {
 })
 
 test_that("get_archival_data_uuid() can query on animal_id", {
-  selected_animal_id <- 59241
-  animal_uuid <-
-    get_archival_data_uuid(animal_id = selected_animal_id)
+  get_archival_data_uuid()$animal_id |>
+    sample(size = 3) |>
+    purrr::walk(
+      \(selected_animal_id){
+        animal_uuid_df <- get_archival_data_uuid(animal_id = selected_animal_id)
+        expect_s3_class(
+          animal_uuid_df,
+          "data.frame"
+        )
 
-  expect_s3_class(
-    animal_uuid,
-    "data.frame"
-  )
-
-  expect_identical(
-    unique(animal_uuid$animal_id),
-    selected_animal_id
-  )
+        expect_identical(
+          unique(animal_uuid_df$animal_id),
+          selected_animal_id
+        )
+      }
+    )
 })
 
 test_that("get_archival_data_uuid() can query on animal_project_code", {


### PR DESCRIPTION
This pull request refactors and significantly expands the test coverage for the `get_archival_data_uuid()` function. The main improvements include making the tests more robust by sampling multiple random values for each parameter, adding randomized case-insensitivity checks, and improving code reuse and clarity.

**Test coverage and robustness improvements:**

* Updated tests for `animal_id`, `animal_project_code`, and `tag_serial_number` to sample and check multiple random values instead of a single hardcoded value, increasing test coverage and reliability.
* Added a new test that verifies `get_archival_data_uuid()` supports case-insensitive queries for `animal_project_code`, using randomized case transformations to ensure robustness.
* Refactored test code to use helper functions for case randomization, improving code clarity and maintainability.
* Ensured all test blocks are properly closed and formatted.