### PR TITLE
Close connections earlier, add fallback to close upon function exit, increase defensiveness. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     readr,
     rlang,
     stringr,
-    utils
+    utils,
+    withr
 Suggests: 
     jsonlite,
     purrr,

--- a/R/get_acoustic_deployment_logs.R
+++ b/R/get_acoustic_deployment_logs.R
@@ -29,6 +29,13 @@ get_acoustic_deployment_logs <- function(credentials = list(
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
   # Check connection
   check_connection(connection)
 

--- a/R/get_acoustic_deployments.R
+++ b/R/get_acoustic_deployments.R
@@ -59,6 +59,13 @@ get_acoustic_deployments <- function(
   connection <-
     connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check if we can make a connection
   check_connection(connection)
 

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -268,6 +268,9 @@ get_acoustic_detections <- function(credentials = list(
     ", .con = connection)
   detections <- DBI::dbGetQuery(connection, query)
 
+  # Close connection
+  DBI::dbDisconnect(connection)
+
   # Sort data (faster than in SQL)
   detections <-
     detections |>
@@ -275,8 +278,6 @@ get_acoustic_detections <- function(credentials = list(
       factor(.data$acoustic_tag_id, levels = list_acoustic_tag_ids(credentials)),
       .data$date_time
     )
-  # Close connection
-  DBI::dbDisconnect(connection)
 
   # Return detections
   dplyr::as_tibble(detections)

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -96,6 +96,13 @@ get_acoustic_detections <- function(credentials = list(
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check if we can make a connection
   check_connection(connection)
 

--- a/R/get_acoustic_detections_page.R
+++ b/R/get_acoustic_detections_page.R
@@ -60,6 +60,13 @@ get_acoustic_detections_page <- function(credentials = list(
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check if we can make a connection
   check_connection(connection)
 

--- a/R/get_acoustic_projects.R
+++ b/R/get_acoustic_projects.R
@@ -37,6 +37,13 @@ get_acoustic_projects <- function(credentials = list(
   connection <-
     connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
   # Check connection
   check_connection(connection)
 

--- a/R/get_acoustic_receivers.R
+++ b/R/get_acoustic_receivers.R
@@ -37,7 +37,13 @@ get_acoustic_receivers <- function(credentials = list(
                                    status = NULL) {
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
   # Check connection
   check_connection(connection)
 

--- a/R/get_acoustic_receivers.R
+++ b/R/get_acoustic_receivers.R
@@ -122,13 +122,13 @@ get_acoustic_receivers <- function(credentials = list(
     ", .con = connection)
   receivers <- DBI::dbGetQuery(connection, query)
 
+  # Close connection
+  DBI::dbDisconnect(connection)
+
   # Sort data
   receivers <-
     receivers |>
     dplyr::arrange(.data$receiver_id)
-
-  # Close connection
-  DBI::dbDisconnect(connection)
 
   # Return receivers
   dplyr::as_tibble(receivers)

--- a/R/get_animal_projects.R
+++ b/R/get_animal_projects.R
@@ -35,7 +35,14 @@ get_animal_projects <- function(credentials = list(
 
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check connection
   check_connection(connection)
 

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -221,6 +221,9 @@ get_animals <- function(credentials = list(
     ", .con = connection)
   animals <- DBI::dbGetQuery(connection, query)
 
+  # Close connection
+  DBI::dbDisconnect(connection)
+
   # Collapse tag information, to obtain one row = one animal
   tag_cols <-
     animals |>
@@ -246,9 +249,6 @@ get_animals <- function(credentials = list(
       .data$release_date_time,
       factor(.data$tag_serial_number, levels = list_tag_serial_numbers(credentials))
     )
-
-  # Close connection
-  DBI::dbDisconnect(connection)
 
   # Return animals
   dplyr::as_tibble(animals) # Is already a tibble, but added if code above changes

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -58,7 +58,14 @@ get_animals <- function(credentials = list(
 
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+ 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check connection
   check_connection(connection)
 

--- a/R/get_archival_data_uuid.R
+++ b/R/get_archival_data_uuid.R
@@ -26,6 +26,13 @@ get_archival_data_uuid <- function(credentials = list(
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
   # Check connection
   check_connection(connection)
 

--- a/R/get_cpod_projects.R
+++ b/R/get_cpod_projects.R
@@ -72,12 +72,13 @@ get_cpod_projects <- function(credentials = list(
     ", .con = connection)
   projects <- DBI::dbGetQuery(connection, query)
 
+  # Close connection
+  DBI::dbDisconnect(connection)
+
   # Sort data
   projects <-
     projects |>
     dplyr::arrange(.data$project_code)
-  # Close connection
-  DBI::dbDisconnect(connection)
 
   # Return data
   dplyr::as_tibble(projects)

--- a/R/get_cpod_projects.R
+++ b/R/get_cpod_projects.R
@@ -35,7 +35,14 @@ get_cpod_projects <- function(credentials = list(
 
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+ 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check connection
   check_connection(connection)
 

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -55,6 +55,13 @@ get_tags <- function(credentials = list(
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
 
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
   # Check connection
   check_connection(connection)
 

--- a/R/list_acoustic_project_codes.R
+++ b/R/list_acoustic_project_codes.R
@@ -10,7 +10,20 @@ list_acoustic_project_codes <- function(credentials = list(
                                           username = Sys.getenv("ETN_USER"),
                                           password = Sys.getenv("ETN_PWD")
                                         )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+  
+  # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
+  check_connection(connection)
 
   project_sql <- glue::glue_sql(
     readr::read_file(system.file("sql", "project.sql", package = "etnservice")),

--- a/R/list_acoustic_tag_ids.R
+++ b/R/list_acoustic_tag_ids.R
@@ -9,7 +9,21 @@ list_acoustic_tag_ids <- function(credentials = list(
   username = Sys.getenv("ETN_USER"),
   password = Sys.getenv("ETN_PWD")
 )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+  
+  # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
+  check_connection(connection)
+
   acoustic_tag_id_sql <- glue::glue_sql(
     readr::read_file(system.file("sql", "acoustic_tag_id.sql", package = "etnservice")),
     .con = connection

--- a/R/list_animal_ids.R
+++ b/R/list_animal_ids.R
@@ -9,11 +9,20 @@ list_animal_ids <- function(credentials = list(
                               username = Sys.getenv("ETN_USER"),
                               password = Sys.getenv("ETN_PWD")
                             )) {
-  stopifnot(is.list(credentials))
-  stopifnot(any(names(credentials) == c("username", "password")))
-
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+  
+  # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
 
+  check_connection(connection)
   query <- glue::glue_sql(
     "SELECT DISTINCT id_pk FROM common.animal_release",
     .con = connection

--- a/R/list_animal_project_codes.R
+++ b/R/list_animal_project_codes.R
@@ -10,8 +10,19 @@ list_animal_project_codes <- function(credentials = list(
                                         username = Sys.getenv("ETN_USER"),
                                         password = Sys.getenv("ETN_PWD")
                                       )) {
-  connection <- connect_to_etn(credentials$username, credentials$password)
+  # Check if credentials object has right shape
+  check_credentials(credentials)
 
+  # Create connection object
+  connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   project_sql <- glue::glue_sql(
     readr::read_file(system.file("sql", "project.sql", package = "etnservice")),
     .con = connection

--- a/R/list_cpod_project_codes.R
+++ b/R/list_cpod_project_codes.R
@@ -16,7 +16,14 @@ list_cpod_project_codes <- function(credentials = list(
 
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   # Check if we can make a connection
   check_connection(connection)
 

--- a/R/list_deployment_ids.R
+++ b/R/list_deployment_ids.R
@@ -9,9 +9,19 @@ list_deployment_ids <- function(credentials = list(
                                   username = Sys.getenv("ETN_USER"),
                                   password = Sys.getenv("ETN_PWD")
                                 )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+  
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   query <- glue::glue_sql(
     "SELECT DISTINCT id_pk FROM acoustic.deployments",
     .con = connection

--- a/R/list_receiver_ids.R
+++ b/R/list_receiver_ids.R
@@ -9,7 +9,19 @@ list_receiver_ids <- function(credentials = list(
                                 username = Sys.getenv("ETN_USER"),
                                 password = Sys.getenv("ETN_PWD")
                               )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+
+  # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
   query <- glue::glue_sql(
     "SELECT DISTINCT receiver FROM acoustic.receivers",
     .con = connection

--- a/R/list_scientific_names.R
+++ b/R/list_scientific_names.R
@@ -10,7 +10,19 @@ list_scientific_names <- function(credentials = list(
                                     username = Sys.getenv("ETN_USER"),
                                     password = Sys.getenv("ETN_PWD")
                                   )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+  
+  # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+
   query <- glue::glue_sql(
     "SELECT DISTINCT scientific_name FROM common.animal_release",
     .con = connection

--- a/R/list_station_names.R
+++ b/R/list_station_names.R
@@ -10,8 +10,19 @@ list_station_names <- function(credentials = list(
                                  username = Sys.getenv("ETN_USER"),
                                  password = Sys.getenv("ETN_PWD")
                                )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+  
+  # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
-
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
+  
   query <- glue::glue_sql(
     "SELECT DISTINCT station_name FROM acoustic.deployments WHERE station_name IS NOT NULL",
     .con = connection

--- a/R/list_tag_serial_numbers.R
+++ b/R/list_tag_serial_numbers.R
@@ -10,8 +10,18 @@ list_tag_serial_numbers <- function(credentials = list(
   username = Sys.getenv("ETN_USER"),
   password = Sys.getenv("ETN_PWD")
 )) {
+  # Check if credentials object has right shape
+  check_credentials(credentials)
+
   # Create connection object
   connection <- connect_to_etn(credentials$username, credentials$password)
+  
+  # Ensure the connection is closed when the function exits, even when it fails.
+  withr::defer(
+    if (DBI::dbIsValid(connection)) {
+      DBI::dbDisconnect(connection)
+    }
+  )
 
   # Check if we can make a connection
   check_connection(connection)

--- a/R/validate_login.R
+++ b/R/validate_login.R
@@ -22,8 +22,8 @@ validate_login <- function(username, password) {
 
   tryCatch(
     {
-      connection <- connect_to_etn(username, password)
-      DBI::dbDisconnect(connection)
+      connection <- 
+        withr::local_db_connection(connect_to_etn(username, password))
       return(TRUE)
     },
     error = function(e) {


### PR DESCRIPTION
I've made small changes in a few instances where a connection was left open longer than absolutly neccesairy. This in an effort to keep as many database connections available as possible at any moment. 

Furthermore I've added a bit of boilerplate that will act as a failsafe and close the connection (if not closed already) when a function exits, even when it crashes. 

Finally I noticed that a number of early exit helpers weren't called for a bunch of functions, so I've added those in to improve error messaging. 


### Diffhunks

* Added `withr::defer` to all functions that open a database connection, ensuring the connection is properly closed when the function exits, even if an error occurs. This change affects files such as `get_acoustic_deployment_logs.R`, `get_acoustic_deployments.R`, `get_acoustic_detections.R`, `get_acoustic_detections_page.R`, `get_acoustic_projects.R`, `get_acoustic_receivers.R`, `get_animal_projects.R`, `get_animals.R`, `get_archival_data_uuid.R`, `get_cpod_projects.R`, `get_tags.R`, and all `list_*` functions. [[1]](diffhunk://#diff-c9ae0c5e9a941d4005d2c2fcd4b8206020b83c3f16c6ef20da25a474478f4098R32-R38) [[2]](diffhunk://#diff-902beb07356fd27dd47760cbbc95ebc22a251f1739345d8f25b45c47fcea4502R62-R68) [[3]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8R99-R105) [[4]](diffhunk://#diff-187c95a146fe8e6ac80316eb9c4a257d127568224063c9ab36980b8ff0eb3b84R63-R69) [[5]](diffhunk://#diff-b9e91684b7bf505845a018bc67968ac27ddf04fd25c1a55df22dcc402fe7a98aR40-R46) [[6]](diffhunk://#diff-9fe6e951d70551725d69e265be8e1fb79c1c45179c7c615ab7ce12339a0ab676R41-R46) [[7]](diffhunk://#diff-629a082601d8db6c16c401ab1a0c8843aea298dabecc09a342550ac02336b493R39-R45) [[8]](diffhunk://#diff-bafc09bb662f482a2cdacaf4db0147d67d693b124f93e7295184c53904112670R62-R68) [[9]](diffhunk://#diff-94b7d56cf3e18890c11e31327ba0db6a337cebc0d664a5f01822c9a5f280c870R29-R35) [[10]](diffhunk://#diff-8aa7c8aa3132addf711c8b00d4db3122c62c748880479eb276aacd0851ceb2c2R39-R45) [[11]](diffhunk://#diff-31df73c65daef614116e7857ac2b0b084185848fd7b6ce07ea63ccfe20661786R58-R64) [[12]](diffhunk://#diff-d6e12ccbee058b4ea894a644861bebb59881a2a0e68cec2e144415ab1be9110fR13-R27) [[13]](diffhunk://#diff-883c6458f66675ffeec176a692d872a5a471546995782dcd812e81e2ee4c3f7fR12-R26) [[14]](diffhunk://#diff-674b0d07e3c40c7356ecc3ece5e456a09291ef123e89d7e33327d6638bfb81feL12-R25) [[15]](diffhunk://#diff-4ad92c51005ca47124c6955de60dc5f27cf99ac9e3ab91787c81a62a51102c20R13-R25) [[16]](diffhunk://#diff-181333fb377906feb9226620f0c9d8c5c538f69be21a24aea7ecdd6a0ed6fcb8R20-R26) [[17]](diffhunk://#diff-210532f053f0128c50928575abb34b5ad81c0fe5c98015db39bb04f98997ff54R12-R24) [[18]](diffhunk://#diff-5af084c967626a9ae375469a94bcd3da00d98593a5d9b13f24c1021cd2f5df06R12-R24) [[19]](diffhunk://#diff-98be477e440a4fd8deedad463543b21213de476797b7661cfc7e7c354be17ba4R13-R25)

* Removed redundant or misplaced manual `DBI::dbDisconnect` calls after data processing, as connection cleanup is now handled automatically. [[1]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8R278-L279) [[2]](diffhunk://#diff-9fe6e951d70551725d69e265be8e1fb79c1c45179c7c615ab7ce12339a0ab676R131-L132) [[3]](diffhunk://#diff-bafc09bb662f482a2cdacaf4db0147d67d693b124f93e7295184c53904112670R231-R233) [[4]](diffhunk://#diff-bafc09bb662f482a2cdacaf4db0147d67d693b124f93e7295184c53904112670L250-L252) [[5]](diffhunk://#diff-8aa7c8aa3132addf711c8b00d4db3122c62c748880479eb276aacd0851ceb2c2R82-L80)

* Replaced inline credential checks (e.g., `stopifnot(...)`) with calls to a centralized `check_credentials` function for consistency and maintainability in all relevant `list_*` functions. [[1]](diffhunk://#diff-d6e12ccbee058b4ea894a644861bebb59881a2a0e68cec2e144415ab1be9110fR13-R27) [[2]](diffhunk://#diff-883c6458f66675ffeec176a692d872a5a471546995782dcd812e81e2ee4c3f7fR12-R26) [[3]](diffhunk://#diff-674b0d07e3c40c7356ecc3ece5e456a09291ef123e89d7e33327d6638bfb81feL12-R25) [[4]](diffhunk://#diff-4ad92c51005ca47124c6955de60dc5f27cf99ac9e3ab91787c81a62a51102c20R13-R25) [[5]](diffhunk://#diff-210532f053f0128c50928575abb34b5ad81c0fe5c98015db39bb04f98997ff54R12-R24) [[6]](diffhunk://#diff-5af084c967626a9ae375469a94bcd3da00d98593a5d9b13f24c1021cd2f5df06R12-R24) [[7]](diffhunk://#diff-98be477e440a4fd8deedad463543b21213de476797b7661cfc7e7c354be17ba4R13-R25)

* Added the `withr` package to the `Imports` section of `DESCRIPTION` to support the new resource management approach.